### PR TITLE
Replaced non-standart innerText with textContent

### DIFF
--- a/src/groups/base.js
+++ b/src/groups/base.js
@@ -17,7 +17,7 @@ Base.prototype.build = function(){
 
 	if (this.spec.name){
 		this.legend = document.createElement('legend');
-		this.legend.innerText = this.spec.name;
+		this.legend.textContent = this.spec.name;
 		this.wrap.appendChild(this.legend);
 	}
 };


### PR DESCRIPTION
Innertext was a specification created by IE that is not fully supported
by other major browsers (webkit only supports it for compatibility reasons).

The behavior of the property is quite undefined even when we compare it between IE releases.

[MDN link](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
